### PR TITLE
Add display depending on app name

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,9 +1,13 @@
 <properties>
     <property id="glasses_name" type="string"></property>
-    <property id="screens" type="string">(1,12,2)(15,4,2)(100)(0)</property>
-    <property id="run" type="string">(1,12,2)(15,4,2)(100)(0)</property>
-    <property id="bike" type="string">(100)(100)(100)</property>
-    <!-- <property id="bike" type="string">(1,2,4)(12,18)(6,14,20,24)(5,13,19,22)(0)</property> -->
+    <property id="screens" type="string">(1,12,2)(15,4,100)(100)(0)</property>
+    <property id="run" type="string">(1,2,4)(1,2,12)(10,18,15)(0)</property>
+    <property id="bike" type="string">(1,2,4)(12,18)(6,14,20,24)(5,13,19,22)(0)</property>
+    <property id="custom_1" type="string">(Vélo Ville)(100)</property>
+    <property id="custom_2" type="string">(Vélo Course)(1,2,4)(12,18)(6,14,20,24)(5,13,19,22)</property>
+    <property id="custom_3" type="string">(VTT)(1,2,4)(12,18)(6,14,20,24)(5,13,19,22)</property>
+    <property id="custom_4" type="string"></property>
+    <property id="custom_5" type="string"></property>
     <property id="is_gesture_enable" type="boolean">true</property>
     <property id="is_auto_loop" type="boolean">false</property>
     <property id="radar_only" type="boolean">true</property>

--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,10 +1,12 @@
 <properties>
     <property id="glasses_name" type="string"></property>
-    <property id="screens" type="string">(1,12,2)(15,4,2)(10,18,22)(0)</property>
-    <property id="run" type="string">(1,2,4)(1,2,12)(10,18,15)(0)</property>
-    <property id="bike" type="string">(1,2,4)(12,18)(6,14,20,24)(5,13,19,22)(0)</property>
+    <property id="screens" type="string">(1,12,2)(15,4,2)(100)(0)</property>
+    <property id="run" type="string">(1,12,2)(15,4,2)(100)(0)</property>
+    <property id="bike" type="string">(100)(100)(100)</property>
+    <!-- <property id="bike" type="string">(1,2,4)(12,18)(6,14,20,24)(5,13,19,22)(0)</property> -->
     <property id="is_gesture_enable" type="boolean">true</property>
     <property id="is_auto_loop" type="boolean">false</property>
+    <property id="radar_only" type="boolean">true</property>
     <property id="loop_timer" type="number">10</property>
     <property id="is_als_enable" type="boolean">true</property>
     <property id="settings_description" type="string">Details on Garmin page of Activelook website.</property>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -20,6 +20,9 @@
     <setting propertyKey="@Properties.is_auto_loop" title="@Strings.settings_is_auto_loop">
         <settingConfig type="boolean" />
     </setting>
+    <setting propertyKey="@Properties.radar_only" title="@Strings.settings_radar_only">
+        <settingConfig type="boolean" />
+    </setting>
     <setting propertyKey="@Properties.loop_timer" title="@Strings.settings_loop_timer">
         <settingConfig type="numeric" min="1" max="30"/>
     </setting>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -14,6 +14,21 @@
     <setting propertyKey="@Properties.screens" title="@Strings.settings_screens">
         <settingConfig type="alphaNumeric" />
     </setting>
+    <setting propertyKey="@Properties.custom_1" title="@Strings.settings_custom_1">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.custom_2" title="@Strings.settings_custom_2">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.custom_3" title="@Strings.settings_custom_3">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.custom_4" title="@Strings.settings_custom_4">
+        <settingConfig type="alphaNumeric" />
+    </setting>
+    <setting propertyKey="@Properties.custom_5" title="@Strings.settings_custom_5">
+        <settingConfig type="alphaNumeric" />
+    </setting>
     <setting propertyKey="@Properties.is_gesture_enable" title="@Strings.settings_is_gesture_enable">
         <settingConfig type="boolean" />
     </setting>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -8,6 +8,11 @@
     <string id="settings_screens">Default</string>
     <string id="settings_run">Running</string>
     <string id="settings_bike">Cycling</string>
+    <string id="settings_custom_1">Custom 1</string>
+    <string id="settings_custom_2">Custom 2</string>
+    <string id="settings_custom_3">Custom 3</string>
+    <string id="settings_custom_4">Custom 4</string>
+    <string id="settings_custom_5">Custom 5</string>
     
     <string id="settings_is_gesture_enable">Enable the gesture sensor</string>
     

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -12,6 +12,7 @@
     <string id="settings_is_gesture_enable">Enable the gesture sensor</string>
     
     <string id="settings_is_auto_loop">Auto-cycle data screens</string>
+    <string id="settings_radar_only">only show radar</string>
     <string id="settings_loop_timer">Adjust screen change interval (sec)</string>
 
     <string id="settings_is_als_enable">Display auto brightness</string>

--- a/source/ActiveLook.mc
+++ b/source/ActiveLook.mc
@@ -71,7 +71,7 @@ module ActiveLookBLE {
         //! Comment and uncomment as needed.
         (:release) private static function _log(msg as Toybox.Lang.String, data as Toybox.Lang.Object or Null) as Void {}
         (:debug)   private static function _log(msg as Toybox.Lang.String, data as Toybox.Lang.Object or Null) as Void {
-            //if ($ has :log) { $.log(Toybox.Lang.format("[ActiveLookBLE::ActiveLook] $1$", [msg]), data); }
+            if ($ has :log) { $.log(Toybox.Lang.format("[ActiveLookBLE::ActiveLook] $1$", [msg]), data); }
         }
 
         //! Interface for delegate

--- a/source/ActiveLookActivityInfo.mc
+++ b/source/ActiveLookActivityInfo.mc
@@ -259,6 +259,7 @@ module ActiveLook {
             [   :averagePace, :averageHeartRate,  :averageCadence ],
             [ :threeSecPower,  :normalizedPower,  :currentCadence, :currentHeartRate,   :chrono, :currentSpeed ],
             [        :chrono,  :elapsedDistance,     :currentPace,      :totalAscent, :altitude ],
+            [:radar],
         ];
 
         const LAYOUTS as Lang.Array<Lang.Symbol> = [
@@ -300,7 +301,11 @@ module ActiveLook {
                     if (spec.find("(0)") == 0) {
                         pages.add(PAGES[0]);
                         spec = spec.substring(3, spec.length());
-                    } else if (spec.find("(") == 0) {
+                    } else if (spec.find("(100)") == 0) {
+                        pages.add(PAGES[12]);
+                        spec = spec.substring(5, spec.length());
+                    } 
+                    else if (spec.find("(") == 0) {
                         var closing = spec.find(")")
                             as Lang.Number or Null;
                         var pSpec = spec.substring(1, closing) as Lang.String ;
@@ -413,6 +418,7 @@ module ActiveLook {
             :lapAverageCadence           => 0x17173333,
             :lapCalories                 => 0x11113636,
             :lapAverageGroundContactTime => 0xBDBDBEBE,
+            :radar => 0x0B0B2B2B,
         };
 
         /*
@@ -518,6 +524,7 @@ module ActiveLook {
             :lapAveragePower 		=> { :full => :averagePowerFullFormat,  :half => :averagePowerHalfFormat  },
             :normalizedPower 		=> { :full => :averagePowerFullFormat,  :half => :averagePowerHalfFormat  },
             :threeSecPower 		    => { :full => :averagePowerFullFormat,  :half => :averagePowerHalfFormat  },
+            :radar 		    => { :full => :radarFullFormat,  :half => :radarHalfFormat },
         };
 
         function toFullChronoStr(value as Lang.Array<Lang.Number> or Null) as Lang.String {
@@ -587,6 +594,14 @@ module ActiveLook {
                 return toHalfStr("-");
             }
             return toHalfStr(Math.round(value).format("%.0f"));
+        }
+        
+        function radarFullFormat(value as Lang.Number or Lang.Float or Null) as Lang.String {
+            return "";
+        }
+        
+        function radarHalfFormat(value as Lang.Number or Lang.Float or Null) as Lang.String {
+            return "";
         }
 
         function toSizedStringDeprecated(value as Lang.Number or Lang.Float or Null, size as Lang.Number) as Lang.String {

--- a/source/ActiveLookDataFieldView.mc
+++ b/source/ActiveLookDataFieldView.mc
@@ -31,6 +31,7 @@ using ActiveLook.Laps;
     Toybox.System.println(Toybox.Lang.format("[D]$1$ $2$", [msg, data]));
 }
 
+var radarOnly as Lang.Boolean = false;
 var sdk as ActiveLookSDK.ALSDK = null as ActiveLookSDK.ALSDK;
 var pagesSpec as Lang.Array<PageSettings.PageSpec> = [] as Lang.Array<PageSettings.PageSpec>;
 var pageIdx as Lang.Number = 0;
@@ -42,7 +43,9 @@ var tempo_lap_freeze as Lang.Number = -1;
 var tempo_congrats as Lang.Number = 1;
 var currentLayouts as Lang.Array<Layouts.GeneratorArguments> = [] as Lang.Array<Layouts.GeneratorArguments>;
 var runningDynamics as Toybox.AntPlus.RunningDynamics or Null = null;
-var mockRadar = false;
+
+(:debug)var mockRadar = true;
+(:release)var mockRadar = false;
 var bikeRadarListener as Radar._MyRadarListenerCommon = mockRadar? new Radar.MockRadarListener() : new Radar.RadarListener();
 var bikeRadar = new Radar.MyBikeRadar(bikeRadarListener);
 var radarView as Radar.RadarView = new Radar.RadarView(bikeRadar, 30, 25, 45,175,false, mockRadar);
@@ -194,7 +197,8 @@ function updateFields() as Void {
         log("updateFields", [i, asStr, $.currentLayouts]);
         $.sdk.updateLayoutValue($.currentLayouts[i][:id], asStr);
     }
-    radarView.updateRadarInfos();
+
+    radarView.updateRadarInfos((after==1 && $.currentLayouts[0][:sym] == :radar) ? 250:30);
     $.sdk.flushGraphicEngine();
 }
 

--- a/source/ActiveLookDataFieldView.mc
+++ b/source/ActiveLookDataFieldView.mc
@@ -7,6 +7,7 @@ using Toybox.WatchUi;
 using Toybox.AntPlus;
 
 using ActiveLookSDK;
+using Radar;
 using ActiveLook.AugmentedActivityInfo;
 using ActiveLook.PageSettings;
 using ActiveLook.Layouts;
@@ -41,6 +42,10 @@ var tempo_lap_freeze as Lang.Number = -1;
 var tempo_congrats as Lang.Number = 1;
 var currentLayouts as Lang.Array<Layouts.GeneratorArguments> = [] as Lang.Array<Layouts.GeneratorArguments>;
 var runningDynamics as Toybox.AntPlus.RunningDynamics or Null = null;
+var mockRadar = false;
+var bikeRadarListener as Radar._MyRadarListenerCommon = mockRadar? new Radar.MockRadarListener() : new Radar.RadarListener();
+var bikeRadar = new Radar.MyBikeRadar(bikeRadarListener);
+var radarView as Radar.RadarView = new Radar.RadarView(bikeRadar, 30, 25, 45,175,false, mockRadar);
 
 // ToDo : différence pause stop
 // 1) Event onTimerStop  devrait être considéré comme un onTimerPause
@@ -183,11 +188,13 @@ function updateFields() as Void {
     }
     $.sdk.flushCmdStackingIfSup(200);
     $.sdk.holdGraphicEngine();
+    radarView.clearRadarArea();
     for (var i = 0; i < after; i++) {
         var asStr = Layouts.get($.currentLayouts[i]);
         log("updateFields", [i, asStr, $.currentLayouts]);
         $.sdk.updateLayoutValue($.currentLayouts[i][:id], asStr);
     }
+    radarView.updateRadarInfos();
     $.sdk.flushGraphicEngine();
 }
 

--- a/source/ActiveLookDataFieldView.mc
+++ b/source/ActiveLookDataFieldView.mc
@@ -65,10 +65,30 @@ var radarView as Radar.RadarView = new Radar.RadarView(bikeRadar, 30, 25, 45,175
 
 (:typecheck(false))
 function resetGlobals() as Void {
+    
+    // $.pagesSpec = PageSettings.strToPages(
+    //     "0, 1,2,3,4,5,6,7,8,9,10,11,(1),(2,3),(4,5,6),(7,8,9,10),(11,12,13,14,15,16),(17,18,19,20,21,22),(23,24,25,27,28,29)",
+    // "1,2,3,0");
+    // $.pagesSpec = PageSettings.strToPages("1,2,3,0", "1,2,3,0");
+    $.pagesSpec = defineScreens();
+    $.pageIdx = 0;
+    $.swipe = false;
+    $.tempo_off = -1;
+    $.tempo_pause = -1;
+    $.tempo_lap_freeze = -1;
+    $.tempo_congrats = 0;
+    $.updateCurrentLayouts(0);
+}
+
+function defineScreens(){
     try {
         var _ai = "screens";
         if (Toybox.Activity has :getProfileInfo) {
             var profileInfo = Toybox.Activity.getProfileInfo();
+            if(profileInfo has :name){
+                var result =  getPageSpecFromCustomSetting(profileInfo.name);
+                if(result !=null) {return PageSettings.strToPages(result,"(1,12,2)(15,4,2)(10,18,22)(0)");}
+            }
             if (profileInfo has :sport) {
                 switch (profileInfo.sport) {
                     case Toybox.Activity.SPORT_RUNNING: { _ai = "run";     break; }
@@ -77,21 +97,23 @@ function resetGlobals() as Void {
                 }
             }
         }
-        $.pagesSpec = PageSettings.strToPages(Application.Properties.getValue(_ai), "(1,12,2)(15,4,2)(10,18,22)(0)");
+       return PageSettings.strToPages(Application.Properties.getValue(_ai), "(1,12,2)(15,4,2)(10,18,22)(0)");
     } catch (e) {
-        $.pagesSpec = PageSettings.strToPages("(1,12,2)(15,4,2)(10,18,22)(0)", null);
+        return PageSettings.strToPages("(1,12,2)(15,4,2)(10,18,22)(0)", null);
     }
-    // $.pagesSpec = PageSettings.strToPages(
-    //     "0, 1,2,3,4,5,6,7,8,9,10,11,(1),(2,3),(4,5,6),(7,8,9,10),(11,12,13,14,15,16),(17,18,19,20,21,22),(23,24,25,27,28,29)",
-    // "1,2,3,0");
-    // $.pagesSpec = PageSettings.strToPages("1,2,3,0", "1,2,3,0");
-    $.pageIdx = 0;
-    $.swipe = false;
-    $.tempo_off = -1;
-    $.tempo_pause = -1;
-    $.tempo_lap_freeze = -1;
-    $.tempo_congrats = 0;
-    $.updateCurrentLayouts(0);
+}
+
+function getPageSpecFromCustomSetting(name as Lang.String){
+    for(var i=1; i<=5; i++){
+        var customProperty = Application.Properties.getValue("custom_" + i.toString()).toString();
+        var endIndex = customProperty.find(")");
+        var currentCustomSport = customProperty.substring(1, endIndex) ;
+        var bool=name.equals(currentCustomSport);
+        if (bool){
+            return customProperty.substring(endIndex + 1, customProperty.length());
+        }
+    }
+    return null;
 }
 
 function updateCurrentLayouts(incr as Lang.Number) as Void {

--- a/source/ActiveLookSDK_next.mc
+++ b/source/ActiveLookSDK_next.mc
@@ -124,7 +124,7 @@ module ActiveLookSDK {
             //if ($ has :log) { $.log(Toybox.Lang.format("[ActiveLookSDK::ALSDK] $1$", [msg]), data); }
         }
 
-        var currentColor = 0;
+        var currentColor = null;
 
         function initialize(obj) {
             listener = obj != null ? obj : self;

--- a/source/ActiveLookSDK_next.mc
+++ b/source/ActiveLookSDK_next.mc
@@ -124,6 +124,8 @@ module ActiveLookSDK {
             //if ($ has :log) { $.log(Toybox.Lang.format("[ActiveLookSDK::ALSDK] $1$", [msg]), data); }
         }
 
+        var currentColor = 0;
+
         function initialize(obj) {
             listener = obj != null ? obj : self;
             ble = ActiveLookBLE.ActiveLook.setUp(self);
@@ -247,6 +249,10 @@ module ActiveLookSDK {
 			return buffer;
 		}
 
+        function sendCommandBuffer(id, data) {
+            self.sendRawCmd(self.commandBuffer(id, data));
+        }
+
         //////////////
         // Commands //
         //////////////
@@ -324,6 +330,48 @@ module ActiveLookSDK {
 			data.addAll(self.stringToPadByteArray(text, null, null));
             self.sendRawCmd(self.commandBuffer(0x37, data));
 		}
+
+        function _buildRectangle(x0 as Lang.Number,y0 as Lang.Number,x1 as Lang.Number,y1 as Lang.Number ) {
+            var data = []b;
+            data.addAll(self.numberToFixedSizeByteArray(x0, 2));
+            data.addAll(self.numberToFixedSizeByteArray(y0, 2));
+            data.addAll(self.numberToFixedSizeByteArray(x1, 2));
+            data.addAll(self.numberToFixedSizeByteArray(y1, 2));
+            return  data;
+        }
+
+        function emptyRectangle(x0 as Lang.Number,y0 as Lang.Number,witdth as Lang.Number,height as Lang.Number ) {
+            self.sendRawCmd(self.commandBuffer(0x33, _buildRectangle(x0,y0, x0 + witdth,y0 +height)));
+		}
+
+        function fullRectangle(x0 as Lang.Number,y0 as Lang.Number,witdth as Lang.Number,height as Lang.Number ) {
+            self.sendRawCmd(self.commandBuffer(0x34, _buildRectangle(x0,y0, x0 + witdth,y0 +height)));
+		}
+
+        function emptyCircle(x as Lang.Number,y as Lang.Number,radius as Lang.Number ) {
+             var data = []b;
+            data.addAll(self.numberToFixedSizeByteArray(x, 2));
+            data.addAll(self.numberToFixedSizeByteArray(y, 2));
+            data.addAll(self.numberToFixedSizeByteArray(radius,1 ));
+            self.sendRawCmd(self.commandBuffer(0x35,data));
+		}
+        function fullCircle(x as Lang.Number,y as Lang.Number,radius as Lang.Number ) {
+            var data = []b;
+            data.addAll(self.numberToFixedSizeByteArray(x, 2));
+            data.addAll(self.numberToFixedSizeByteArray(y, 2));
+            data.addAll(self.numberToFixedSizeByteArray(radius,1 ));
+            self.sendRawCmd(self.commandBuffer(0x36,data));
+		}
+
+        function changeColor(colorValue as Lang.Number){
+            if(self.currentColor != colorValue){
+                self.currentColor=colorValue;
+                $.sdk.sendCommandBuffer(0x30, [colorValue]);
+            }
+            return;
+        }
+
+
 
         function holdGraphicEngine(){
             _log("holdGraphicEngine", []);

--- a/source/Radar.mc
+++ b/source/Radar.mc
@@ -38,18 +38,6 @@ module Radar {
     function initialize() {
       _MyRadarListenerCommon.initialize();
 
-      self.radarInfos = [
-        new MyRadarTarget(139.0, 90.0,
-                          AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
-                          AntPlus.THREAT_SIDE_LEFT),
-        new MyRadarTarget(58.0, 30.0, AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
-                          AntPlus.THREAT_SIDE_RIGHT),
-        new MyRadarTarget(30.0, 50.0, AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
-                          AntPlus.THREAT_SIDE_NO_SIDE),
-        new MyRadarTarget(72.0, 120.0,
-                          AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
-                          AntPlus.THREAT_SIDE_NO_SIDE)
-      ];
     }
 
     function onBikeRadarUpdate(data) {
@@ -60,6 +48,9 @@ module Radar {
         self.radarInfos[i].range = self.radarInfos[i].range - 15;
         if (self.radarInfos[i].range < 0) {
           self.radarInfos[i].range = self.radarInfos[i].range;
+          self.radarInfos.remove(radarInfos[i]);
+          i--;
+          continue;
         }
         if (self.radarInfos[i].range > self.maxRadarRange) {
           self.maxRadarRange = self.radarInfos[i].range;
@@ -70,18 +61,19 @@ module Radar {
         if (emulatorIterationCount < emulatorIterationBeforeSetBackvalue) {
           emulatorIterationCount++;
         } else {
+          emulatorIterationCount= 0;
           self.radarInfos = [
-            new MyRadarTarget(139.0, 90.0,
+            new MyRadarTarget(30.0, 90.0,
                               AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
                               AntPlus.THREAT_SIDE_LEFT),
             new MyRadarTarget(58.0, 30.0,
-                              AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
+                              AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
                               AntPlus.THREAT_SIDE_RIGHT),
-            new MyRadarTarget(30.0, 50.0,
+            new MyRadarTarget(90.0, 50.0,
                               AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
                               AntPlus.THREAT_SIDE_NO_SIDE),
-            new MyRadarTarget(72.0, 120.0,
-                              AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
+            new MyRadarTarget(139.0, 120.0,
+                              AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
                               AntPlus.THREAT_SIDE_NO_SIDE)
           ];
         }
@@ -159,14 +151,7 @@ module Radar {
       self.mockRadar = mockRadar;
     }
 
-    function _showSlowVehicule(x as Lang.Number, y as Lang.Number,
-                               radius as Lang.Number) {
-      $.sdk.changeColor(self.atLeastOneFastVehicule ? 0 : 8);
-      $.sdk.fullCircle(x, y, radius);
 
-      $.sdk.changeColor(self.atLeastOneFastVehicule ? 8 : 0);
-      $.sdk.fullCircle(x, y, (radius * 0.6).toNumber());
-    }
 
     function _showVehicule(x as Lang.Number, height as Lang.Number,
                            radarInfo as Radar.MyRadarTarget) {
@@ -175,13 +160,8 @@ module Radar {
         var yValue = height - radarInfo.range.toNumber() * MAX_RANGE_DETECTION /
                                   (height - self.borderOffset * 2);
         if (yValue > 0) {
-          if (radarInfo.threat ==
-              AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING) {
-            $.sdk.changeColor(0);
-            $.sdk.fullCircle(x, yValue.toNumber(), 10);
-          } else {
-            self._showSlowVehicule(x, yValue.toNumber(), 10);
-          }
+            $.sdk.changeColor(self.atLeastOneFastVehicule ? 0 : 8);
+            $.sdk.fullCircle(x, yValue.toNumber(),self.atLeastOneFastVehicule ?8 :6);
         }
       }
     }
@@ -209,7 +189,8 @@ module Radar {
       return false;
     }
 
-    function updateRadarInfos() {
+    function updateRadarInfos(xScreenProtectionArea as Lang.Number) {
+      self.xScreenProtectionArea = xScreenProtectionArea;
       if (self.mockRadar) {
         self.bikeRadar.listener.onBikeRadarUpdate([new AntPlus.RadarTarget()]);
       }
@@ -222,7 +203,9 @@ module Radar {
           $.sdk.changeColor(0);
           toggleCircleIndicator = true;
         }
-        $.sdk.fullCircle(110, 212, 6);
+        $.sdk.fullCircle(
+            self.xScreenProtectionArea > 110 ? self.xScreenProtectionArea + self.radarAreaWidth*3/4 : 110,
+            212, 6);
         if (self.bikeRadar.getMaxRange() > 0) {
           $.sdk.changeColor(8);
           $.sdk.fullRectangle(self.xScreenProtectionArea,

--- a/source/Radar.mc
+++ b/source/Radar.mc
@@ -1,0 +1,255 @@
+using Toybox.AntPlus;
+using Toybox.Lang;
+
+module Radar {
+  class MyRadarTarget extends AntPlus.RadarTarget {
+    function initialize(rangeI as Lang.Float, speedI as Lang.Float,
+                        threatI as AntPlus.ThreatLevel,
+                        threatSideI as AntPlus.ThreatSide) {
+      AntPlus.RadarTarget.initialize();
+      range = rangeI;
+      speed = speedI;
+      threat = threatI;
+      threatSide = threatSideI;
+    }
+  }
+
+  class _MyRadarListenerCommon extends Toybox.AntPlus.BikeRadarListener {
+    const NUMBER_OF_THREAT as Lang.Number = 8;
+    var radarInfos as Lang.Array<MyRadarTarget> = [];
+    var maxRadarRange as Lang.Float = 0.0;
+    var radarConnected as Lang.Boolean = false;
+
+    function initialize() { AntPlus.BikeRadarListener.initialize(); }
+
+    function getRadarInfos() as Lang.Array<MyRadarTarget> {
+      return self.radarInfos;
+    }
+
+    function getMaxRange() as Lang.Float { return self.maxRadarRange; }
+
+    function getRadarConnected() as Lang.Boolean { return radarConnected; }
+  }
+
+  class MockRadarListener extends _MyRadarListenerCommon {
+    const emulatorIterationBeforeSetBackvalue as Lang.Number = 5;
+    var emulatorIterationCount as Lang.Number = 0;
+
+    function initialize() {
+      _MyRadarListenerCommon.initialize();
+
+      self.radarInfos = [
+        new MyRadarTarget(139.0, 90.0,
+                          AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
+                          AntPlus.THREAT_SIDE_LEFT),
+        new MyRadarTarget(58.0, 30.0, AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
+                          AntPlus.THREAT_SIDE_RIGHT),
+        new MyRadarTarget(30.0, 50.0, AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
+                          AntPlus.THREAT_SIDE_NO_SIDE),
+        new MyRadarTarget(72.0, 120.0,
+                          AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
+                          AntPlus.THREAT_SIDE_NO_SIDE)
+      ];
+    }
+
+    function onBikeRadarUpdate(data) {
+      self.radarConnected = true;
+      self.maxRadarRange = 0.0;
+
+      for (var i = 0; i < self.radarInfos.size(); i++) {
+        self.radarInfos[i].range = self.radarInfos[i].range - 15;
+        if (self.radarInfos[i].range < 0) {
+          self.radarInfos[i].range = self.radarInfos[i].range;
+        }
+        if (self.radarInfos[i].range > self.maxRadarRange) {
+          self.maxRadarRange = self.radarInfos[i].range;
+        }
+      }
+
+      if (self.maxRadarRange == 0) {
+        if (emulatorIterationCount < emulatorIterationBeforeSetBackvalue) {
+          emulatorIterationCount++;
+        } else {
+          self.radarInfos = [
+            new MyRadarTarget(139.0, 90.0,
+                              AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
+                              AntPlus.THREAT_SIDE_LEFT),
+            new MyRadarTarget(58.0, 30.0,
+                              AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
+                              AntPlus.THREAT_SIDE_RIGHT),
+            new MyRadarTarget(30.0, 50.0,
+                              AntPlus.THREAT_LEVEL_VEHICLE_APPROACHING,
+                              AntPlus.THREAT_SIDE_NO_SIDE),
+            new MyRadarTarget(72.0, 120.0,
+                              AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING,
+                              AntPlus.THREAT_SIDE_NO_SIDE)
+          ];
+        }
+      }
+    }
+  }
+
+  class RadarListener extends _MyRadarListenerCommon {
+    function initialize() { _MyRadarListenerCommon.initialize(); }
+
+    function onBikeRadarUpdate(data) {
+      // Handle the radar update data here
+      self.radarInfos = [];
+      self.maxRadarRange = 0.0;
+
+      if (data != null) {
+        self.radarConnected = true;
+        for (var i = 0; i < NUMBER_OF_THREAT; i++) {
+          if (data[i].range.toNumber() > self.maxRadarRange) {
+            self.maxRadarRange = data[i].range;
+          }
+          self.radarInfos.add(new MyRadarTarget(data[i].range, data[i].speed,
+                                                data[i].threat,
+                                                data[i].threatSide));
+        }
+      }
+    }
+  }
+
+  class MyBikeRadar extends Toybox.AntPlus.BikeRadar {
+    var radarInfos as Lang.Array<MyRadarTarget> = [];
+    var maxRadarRange as Lang.Float = 0.0;
+    var listener as _MyRadarListenerCommon;
+
+    function initialize(listener as _MyRadarListenerCommon or Null) {
+      AntPlus.BikeRadar.initialize(listener);
+      self.listener = listener;
+    }
+
+    function getRadarInfos() as Lang.Array<MyRadarTarget> {
+      return self.listener.getRadarInfos();
+    }
+
+    function getMaxRange() as Lang.Float { return self.listener.getMaxRange(); }
+
+    function isConnected() { return self.listener.getRadarConnected(); }
+  }
+
+  class RadarView {
+    var bikeRadar as MyBikeRadar;
+    var xScreenProtectionArea as Lang.Number;
+    var yScreenProtectionArea as Lang.Number;
+    var MAX_RANGE_DETECTION as Lang.Number = 170;
+    var radarAreaWidth as Lang.Number;
+    var radarAreaHeight as Lang.Number;
+    var radarAreaIsClean as Lang.Boolean;
+    var mockRadar as Lang.Boolean = false;
+    var toggleCircleIndicator as Lang.Boolean = false;
+    const borderOffset as Lang.Number = 8;
+    var atLeastOneFastVehicule as Lang.Boolean = false;
+
+    function initialize(bikeRadar as MyBikeRadar,
+                        xScreenProtectionArea as Lang.Number,
+                        yScreenProtectionArea as Lang.Number,
+                        radarAreaWidth as Lang.Number,
+                        radarAreaHeight as Lang.Number,
+                        radarAreaIsClean as Lang.Boolean,
+                        mockRadar as Lang.Boolean) {
+      self.bikeRadar = bikeRadar;
+      self.xScreenProtectionArea = xScreenProtectionArea;
+      self.yScreenProtectionArea = yScreenProtectionArea;
+      self.radarAreaWidth = radarAreaWidth;
+      self.radarAreaHeight = radarAreaHeight;
+      self.radarAreaIsClean = radarAreaIsClean;
+      self.mockRadar = mockRadar;
+    }
+
+    function _showSlowVehicule(x as Lang.Number, y as Lang.Number,
+                               radius as Lang.Number) {
+      $.sdk.changeColor(self.atLeastOneFastVehicule ? 0 : 8);
+      $.sdk.fullCircle(x, y, radius);
+
+      $.sdk.changeColor(self.atLeastOneFastVehicule ? 8 : 0);
+      $.sdk.fullCircle(x, y, (radius * 0.6).toNumber());
+    }
+
+    function _showVehicule(x as Lang.Number, height as Lang.Number,
+                           radarInfo as Radar.MyRadarTarget) {
+      $.sdk.changeColor(self.atLeastOneFastVehicule ? 0 : 8);
+      if (radarInfo.range < MAX_RANGE_DETECTION && radarInfo.range > 0) {
+        var yValue = height - radarInfo.range.toNumber() * MAX_RANGE_DETECTION /
+                                  (height - self.borderOffset * 2);
+        if (yValue > 0) {
+          if (radarInfo.threat ==
+              AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING) {
+            $.sdk.changeColor(0);
+            $.sdk.fullCircle(x, yValue.toNumber(), 10);
+          } else {
+            self._showSlowVehicule(x, yValue.toNumber(), 10);
+          }
+        }
+      }
+    }
+
+    function clearRadarArea() {
+      if (self.bikeRadar.isConnected() && self.bikeRadar.getMaxRange() == 0 &&
+          self.radarAreaIsClean == false) {
+        $.sdk.changeColor(0);
+        $.sdk.fullRectangle(self.xScreenProtectionArea,
+                            self.yScreenProtectionArea, self.radarAreaWidth,
+                            self.radarAreaHeight);
+        $.sdk.resetLayouts([]);
+        radarAreaIsClean = true;
+      }
+    }
+
+    function _isThereAtLeastOneFastVehicule(
+        radarInfos as Lang.Array<Radar.MyRadarTarget>) as Lang.Boolean {
+      for (var i = 0; i < self.bikeRadar.getRadarInfos().size(); i++) {
+        if (radarInfos[i].threat ==
+            AntPlus.THREAT_LEVEL_VEHICLE_FAST_APPROACHING) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    function updateRadarInfos() {
+      if (self.mockRadar) {
+        self.bikeRadar.listener.onBikeRadarUpdate([new AntPlus.RadarTarget()]);
+      }
+
+      if (self.bikeRadar.isConnected()) {
+        if (toggleCircleIndicator) {
+          $.sdk.changeColor(8);
+          toggleCircleIndicator = false;
+        } else {
+          $.sdk.changeColor(0);
+          toggleCircleIndicator = true;
+        }
+        $.sdk.fullCircle(110, 212, 6);
+        if (self.bikeRadar.getMaxRange() > 0) {
+          $.sdk.changeColor(8);
+          $.sdk.fullRectangle(self.xScreenProtectionArea,
+                              self.yScreenProtectionArea, self.radarAreaWidth,
+                              self.radarAreaHeight);
+
+          self.atLeastOneFastVehicule = self._isThereAtLeastOneFastVehicule(
+              self.bikeRadar.getRadarInfos());
+          if (self.atLeastOneFastVehicule == false) {
+            $.sdk.changeColor(0);
+            $.sdk.fullRectangle(self.xScreenProtectionArea + self.borderOffset,
+                                self.yScreenProtectionArea + self.borderOffset,
+                                self.radarAreaWidth - self.borderOffset * 2,
+                                self.radarAreaHeight - self.borderOffset * 2);
+          }
+
+          for (var i = 0; i < self.bikeRadar.getRadarInfos().size(); i++) {
+            var radarInfo =
+                (self.bikeRadar.getRadarInfos())[i] as Radar.MyRadarTarget;
+            self._showVehicule(
+                self.xScreenProtectionArea + self.radarAreaWidth / 2,
+                self.radarAreaHeight, radarInfo);
+          }
+
+          self.radarAreaIsClean = false;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add 5 Custom fields with first () pattern include app name to display screens depending on app name rather than sport category.  
 e.g. different screen pattern for different bike use case, city bike or MTB or Road bike